### PR TITLE
Feature/analytics graphs

### DIFF
--- a/src/API/APIcalls.js
+++ b/src/API/APIcalls.js
@@ -18,10 +18,10 @@ export const fetchUserLogin = async (email) => {
   }
 };
 
-export const fetchUserDreams = async (token) => {
+export const fetchUserDreams = async (token, dateStart, dateEnd) => {
   try {
     const response = await fetch(
-      'https://vivid-project-backend.herokuapp.com/dreams',
+      `https://vivid-project-backend.herokuapp.com/dreams?dateStart=${dateStart}&dateEnd=${dateEnd}`,
       {
         method: 'GET',
         headers: {

--- a/src/API/APIcalls.js
+++ b/src/API/APIcalls.js
@@ -18,7 +18,25 @@ export const fetchUserLogin = async (email) => {
   }
 };
 
-export const fetchUserDreams = async (token, dateStart, dateEnd) => {
+export const fetchUserDreams = async (token) => {
+  try {
+    const response = await fetch(
+      `https://vivid-project-backend.herokuapp.com/dreams`,
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: token,
+        },
+      }
+    );
+    return await response.json();
+  } catch (error) {
+    return console.log(error);
+  }
+};
+
+export const fetchUserDreamsByDates = async (token, dateStart, dateEnd) => {
   try {
     const response = await fetch(
       `https://vivid-project-backend.herokuapp.com/dreams?dateStart=${dateStart}&dateEnd=${dateEnd}`,

--- a/src/common/LineGraph.js
+++ b/src/common/LineGraph.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Line } from 'react-chartjs-2';
+
+const LineGraph = () => {
+  const data = {
+    labels: ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
+    datasets: [
+      {
+        label: 'My First dataset',
+        fill: false,
+        lineTension: 0.1,
+        backgroundColor: 'rgba(75,192,192,0.4)',
+        borderColor: 'rgba(75,192,192,1)',
+        borderCapStyle: 'butt',
+        borderDash: [],
+        borderDashOffset: 0.0,
+        borderJoinStyle: 'miter',
+        pointBorderColor: 'rgba(75,192,192,1)',
+        pointBackgroundColor: '#fff',
+        pointBorderWidth: 1,
+        pointHoverRadius: 5,
+        pointHoverBackgroundColor: 'rgba(75,192,192,1)',
+        pointHoverBorderColor: 'rgba(220,220,220,1)',
+        pointHoverBorderWidth: 2,
+        pointRadius: 1,
+        pointHitRadius: 10,
+        data: [65, 59, 80, 81, 56, 55, 40],
+      },
+    ],
+  };
+
+  return <Line data={data} />;
+};
+
+export default LineGraph;

--- a/src/common/LineGraph.js
+++ b/src/common/LineGraph.js
@@ -8,23 +8,29 @@ import fakeDreams from '../data/fakeDreams';
 const TonesOverTime = () => {
   const user = useContext(UserContext);
   const [allDreams, setAllDreams] = useState(fakeDreams.dreams);
-  const [graphData, setGraphData] = useState({ x: [], y: [] });
   const [chartDayCount, setChartCount] = useState(30);
-  const [chartDates, setChartDates] = useState([]);
+  const [chartDates, setChartDates] = useState(null);
 
   useEffect(() => {
     buildChartDates();
-    processDreamData();
     // API.fetchUserDreams(user.token).then((r) => {
     //   setAllDreams(r);
     // });
   }, [chartDayCount]);
 
+  useEffect(() => {
+    if (!chartDates) return;
+
+    processDreamData();
+  }, [chartDates]);
+
   const getDateToday = (dayModifier) => {
     const date = new Date();
+
     if (dayModifier) {
       date.setDate(date.getDate() + dayModifier);
     }
+
     const dd = String(date.getDate()).padStart(2, '0');
     const mm = String(date.getMonth() + 1).padStart(2, '0');
     const yyyy = date.getFullYear();
@@ -34,21 +40,25 @@ const TonesOverTime = () => {
   const buildChartDates = () => {
     let day = 0;
     const daysOfWeek = [];
+
     while (daysOfWeek.length < chartDayCount) {
       daysOfWeek.push(getDateToday(day));
       day--;
     }
+
     setChartDates(daysOfWeek);
   };
 
   const buildToneValues = (toneData) => {
-    // const values = chartDates.reduce((dateValues, date) => {
-    //   if (!toneData[date]) {
-    //     toneData[date] = 0;
-    //   }
-    //   return dateValues.push(toneData[date]);
-    // }, []);
-    // console.log(values);
+    return chartDates.reduce((dateValues, date) => {
+      if (!toneData[date]) {
+        toneData[date] = 0;
+      }
+
+      dateValues.push(toneData[date]);
+
+      return dateValues;
+    }, []);
   };
 
   const processDreamData = () => {
@@ -56,18 +66,20 @@ const TonesOverTime = () => {
       Object.entries(dream.toneAnalysis.tone_strength).forEach((tonePair) => {
         let tone = tonePair[0];
         let freq = tonePair[1];
+
         if (!toneFreqs[tone]) {
-          toneFreqs[tone] = { [dream.date]: 0 };
+          toneFreqs[tone] = {};
         }
+
         if (!toneFreqs[tone][dream.date]) {
           toneFreqs[tone][dream.date] = 0;
         }
+
         toneFreqs[tone][dream.date] += freq;
       });
 
       return toneFreqs;
     }, {});
-    console.log(toneDatesAndFreqs);
     buildToneValues(toneDatesAndFreqs.Analytical);
   };
 

--- a/src/common/LineGraph.js
+++ b/src/common/LineGraph.js
@@ -1,7 +1,43 @@
-import React from 'react';
+import React, { useEffect, useContext, useState } from 'react';
 import { Line } from 'react-chartjs-2';
+import UserContext from '../modules/Context/UserContext';
+import * as API from '../API/APIcalls';
+
+import fakeDreams from '../data/fakeDreams';
 
 const TonesOverTime = () => {
+  const user = useContext(UserContext);
+  const [allDreams, setAllDreams] = useState(fakeDreams.dreams);
+  const [graphData, setGraphData] = useState({ x: [], y: [] });
+
+  useEffect(() => {
+    // setAllDreams(fakeDreams.dreams);
+    processDreamData();
+
+    // API.fetchUserDreams(user.token).then((r) => {
+    //   setAllDreams(r);
+    // });
+  }, []);
+
+  const processDreamData = () => {
+    const toneDatesAndFreqs = allDreams.reduce((toneFreqs, dream) => {
+      Object.entries(dream.toneAnalysis.tone_strength).forEach((tonePair) => {
+        let tone = tonePair[0];
+        let freq = tonePair[1];
+        if (!toneFreqs[tone]) {
+          toneFreqs[tone] = { [dream.date]: 0 };
+        }
+        if (!toneFreqs[tone][dream.date]) {
+          toneFreqs[tone][dream.date] = 0;
+        }
+        toneFreqs[tone][dream.date] += freq;
+      });
+
+      return toneFreqs;
+    }, {});
+    console.log(toneDatesAndFreqs);
+  };
+
   const data = {
     labels: ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
     datasets: [

--- a/src/common/LineGraph.js
+++ b/src/common/LineGraph.js
@@ -11,6 +11,7 @@ const TonesOverTime = () => {
   const [chartDayCount, setChartCount] = useState(7);
   const [chartDates, setChartDates] = useState(null);
   const [chartTones, setChartTones] = useState([]);
+  const [chartPlotDatasets, setChartPlotDatasets] = useState([]);
 
   useEffect(() => {
     buildChartDates();
@@ -23,12 +24,8 @@ const TonesOverTime = () => {
     if (!chartDates) return;
     processDreamData();
     console.log(chartTones);
-    // plotChartTones();
+    createPlotChartDatasets();
   }, [chartDates]);
-
-  // const plotChartTones = () => {
-
-  // }
 
   const getDateToday = (dayModifier) => {
     const date = new Date();
@@ -59,7 +56,7 @@ const TonesOverTime = () => {
       if (!toneData[date]) {
         toneData[date] = 0;
       }
-      dateValues.push(toneData[date]);
+      dateValues.unshift(toneData[date]);
       return dateValues;
     }, []);
     setChartTones(chartTones.push({ [tone]: toneDates }));
@@ -93,11 +90,11 @@ const TonesOverTime = () => {
     buildToneValues(toneDatesAndFreqs);
   };
 
-  const data = {
-    labels: chartDates,
-    datasets: [
-      {
-        label: 'My First dataset',
+  const createPlotChartDatasets = () => {
+    const chartPlotData = chartTones.map((tone) => {
+      // debugger;
+      return {
+        label: Object.keys(tone),
         fill: false,
         lineTension: 0.1,
         backgroundColor: 'rgba(75,192,192,0.4)',
@@ -115,9 +112,15 @@ const TonesOverTime = () => {
         pointHoverBorderWidth: 2,
         pointRadius: 1,
         pointHitRadius: 10,
-        data: [65, 59, 80, 81, 56, 55, 40],
-      },
-    ],
+        data: Object.values(tone)[0],
+      };
+    });
+    setChartPlotDatasets(chartPlotData);
+  };
+
+  const data = {
+    labels: chartDates,
+    datasets: chartPlotDatasets,
   };
 
   return <Line data={data} />;

--- a/src/common/LineGraph.js
+++ b/src/common/LineGraph.js
@@ -90,19 +90,27 @@ const TonesOverTime = () => {
     buildToneValues(toneDatesAndFreqs);
   };
 
+  const getRandomColor = () => {
+    var letters = '0123456789ABCDEF'.split('');
+    var color = '#';
+    for (var i = 0; i < 6; i++) {
+      color += letters[Math.floor(Math.random() * 16)];
+    }
+    return color;
+  };
+
   const createPlotChartDatasets = () => {
     const chartPlotData = chartTones.map((tone) => {
-      // debugger;
       return {
         label: Object.keys(tone),
         fill: false,
-        lineTension: 0.1,
+        lineTension: 0.2,
         backgroundColor: 'rgba(75,192,192,0.4)',
-        borderColor: 'rgba(75,192,192,1)',
+        borderColor: getRandomColor(),
         borderCapStyle: 'butt',
         borderDash: [],
         borderDashOffset: 0.0,
-        borderJoinStyle: 'miter',
+        borderJoinStyle: 'round',
         pointBorderColor: 'rgba(75,192,192,1)',
         pointBackgroundColor: '#fff',
         pointBorderWidth: 1,
@@ -110,7 +118,7 @@ const TonesOverTime = () => {
         pointHoverBackgroundColor: 'rgba(75,192,192,1)',
         pointHoverBorderColor: 'rgba(220,220,220,1)',
         pointHoverBorderWidth: 2,
-        pointRadius: 1,
+        pointRadius: 0,
         pointHitRadius: 10,
         data: Object.values(tone)[0],
       };

--- a/src/common/LineGraph.js
+++ b/src/common/LineGraph.js
@@ -9,15 +9,47 @@ const TonesOverTime = () => {
   const user = useContext(UserContext);
   const [allDreams, setAllDreams] = useState(fakeDreams.dreams);
   const [graphData, setGraphData] = useState({ x: [], y: [] });
+  const [chartDayCount, setChartCount] = useState(30);
+  const [chartDates, setChartDates] = useState([]);
 
   useEffect(() => {
-    // setAllDreams(fakeDreams.dreams);
+    buildChartDates();
     processDreamData();
-
     // API.fetchUserDreams(user.token).then((r) => {
     //   setAllDreams(r);
     // });
-  }, []);
+  }, [chartDayCount]);
+
+  const getDateToday = (dayModifier) => {
+    const date = new Date();
+    if (dayModifier) {
+      date.setDate(date.getDate() + dayModifier);
+    }
+    const dd = String(date.getDate()).padStart(2, '0');
+    const mm = String(date.getMonth() + 1).padStart(2, '0');
+    const yyyy = date.getFullYear();
+    return `${yyyy}/${mm}/${dd}`;
+  };
+
+  const buildChartDates = () => {
+    let day = 0;
+    const daysOfWeek = [];
+    while (daysOfWeek.length < chartDayCount) {
+      daysOfWeek.push(getDateToday(day));
+      day--;
+    }
+    setChartDates(daysOfWeek);
+  };
+
+  const buildToneValues = (toneData) => {
+    // const values = chartDates.reduce((dateValues, date) => {
+    //   if (!toneData[date]) {
+    //     toneData[date] = 0;
+    //   }
+    //   return dateValues.push(toneData[date]);
+    // }, []);
+    // console.log(values);
+  };
 
   const processDreamData = () => {
     const toneDatesAndFreqs = allDreams.reduce((toneFreqs, dream) => {
@@ -36,10 +68,11 @@ const TonesOverTime = () => {
       return toneFreqs;
     }, {});
     console.log(toneDatesAndFreqs);
+    buildToneValues(toneDatesAndFreqs.Analytical);
   };
 
   const data = {
-    labels: ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
+    labels: chartDates,
     datasets: [
       {
         label: 'My First dataset',

--- a/src/common/LineGraph.js
+++ b/src/common/LineGraph.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Line } from 'react-chartjs-2';
 
-const LineGraph = () => {
+const TonesOverTime = () => {
   const data = {
     labels: ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
     datasets: [
@@ -32,4 +32,4 @@ const LineGraph = () => {
   return <Line data={data} />;
 };
 
-export default LineGraph;
+export default TonesOverTime;

--- a/src/common/LineGraph.js
+++ b/src/common/LineGraph.js
@@ -8,8 +8,9 @@ import fakeDreams from '../data/fakeDreams';
 const TonesOverTime = () => {
   const user = useContext(UserContext);
   const [allDreams, setAllDreams] = useState(fakeDreams.dreams);
-  const [chartDayCount, setChartCount] = useState(30);
+  const [chartDayCount, setChartCount] = useState(7);
   const [chartDates, setChartDates] = useState(null);
+  const [chartTones, setChartTones] = useState([]);
 
   useEffect(() => {
     buildChartDates();
@@ -20,9 +21,14 @@ const TonesOverTime = () => {
 
   useEffect(() => {
     if (!chartDates) return;
-
     processDreamData();
+    console.log(chartTones);
+    // plotChartTones();
   }, [chartDates]);
+
+  // const plotChartTones = () => {
+
+  // }
 
   const getDateToday = (dayModifier) => {
     const date = new Date();
@@ -45,20 +51,24 @@ const TonesOverTime = () => {
       daysOfWeek.push(getDateToday(day));
       day--;
     }
-
     setChartDates(daysOfWeek);
   };
 
-  const buildToneValues = (toneData) => {
-    return chartDates.reduce((dateValues, date) => {
+  const createIndividualToneData = (tone, toneData) => {
+    const toneDates = chartDates.reduce((dateValues, date) => {
       if (!toneData[date]) {
         toneData[date] = 0;
       }
-
       dateValues.push(toneData[date]);
-
       return dateValues;
     }, []);
+    setChartTones(chartTones.push({ [tone]: toneDates }));
+  };
+
+  const buildToneValues = (toneData) => {
+    Object.keys(toneData).forEach((tone) =>
+      createIndividualToneData(tone, toneData[tone])
+    );
   };
 
   const processDreamData = () => {
@@ -80,7 +90,7 @@ const TonesOverTime = () => {
 
       return toneFreqs;
     }, {});
-    buildToneValues(toneDatesAndFreqs.Analytical);
+    buildToneValues(toneDatesAndFreqs);
   };
 
   const data = {

--- a/src/common/TonesOverTime.js
+++ b/src/common/TonesOverTime.js
@@ -21,7 +21,8 @@ const TonesOverTime = () => {
 
   useEffect(() => {
     if (!chartDates) return;
-    API.fetchUserDreams(
+    debugger;
+    API.fetchUserDreamsByDates(
       user.token,
       chartDates[0],
       chartDates[chartDates.length - 1]

--- a/src/common/TonesOverTime.js
+++ b/src/common/TonesOverTime.js
@@ -4,10 +4,12 @@ import UserContext from '../modules/Context/UserContext';
 import * as API from '../API/APIcalls';
 
 import fakeDreams from '../data/fakeDreams';
+import fakeUser from '../data/fakeUser';
 
 const TonesOverTime = () => {
   const user = useContext(UserContext);
-  const [allDreams, setAllDreams] = useState(fakeDreams.dreams);
+  // const user = fakeUser;
+  const [allDreams, setAllDreams] = useState([]);
   const [chartDayCount, setChartCount] = useState(7);
   const [chartDates, setChartDates] = useState(null);
   const [chartTones, setChartTones] = useState([]);
@@ -15,15 +17,20 @@ const TonesOverTime = () => {
 
   useEffect(() => {
     buildChartDates();
-    // API.fetchUserDreams(user.token).then((r) => {
-    //   setAllDreams(r);
-    // });
   }, [chartDayCount]);
 
   useEffect(() => {
     if (!chartDates) return;
+    API.fetchUserDreams(
+      user.token,
+      chartDates[0],
+      chartDates[chartDates.length - 1]
+    ).then((r) => {
+      console.log(r);
+      setAllDreams(r);
+    });
+
     processDreamData();
-    console.log(chartTones);
     createPlotChartDatasets();
   }, [chartDates]);
 

--- a/src/common/TonesOverTime.js
+++ b/src/common/TonesOverTime.js
@@ -8,9 +8,8 @@ import fakeUser from '../data/fakeUser';
 
 const TonesOverTime = () => {
   const user = useContext(UserContext);
-  // const user = fakeUser;
-  const [allDreams, setAllDreams] = useState([]);
-  const [chartDayCount, setChartCount] = useState(7);
+  const [allDreams, setAllDreams] = useState(null);
+  const [chartDayCount, setChartCount] = useState(70);
   const [chartDates, setChartDates] = useState(null);
   const [chartTones, setChartTones] = useState([]);
   const [chartPlotDatasets, setChartPlotDatasets] = useState([]);
@@ -21,19 +20,21 @@ const TonesOverTime = () => {
 
   useEffect(() => {
     if (!chartDates) return;
-    debugger;
     API.fetchUserDreamsByDates(
       user.token,
-      chartDates[0],
-      chartDates[chartDates.length - 1]
+      chartDates[chartDates.length - 1],
+      chartDates[0]
     ).then((r) => {
-      console.log(r);
       setAllDreams(r);
+      console.log(r);
     });
+  }, [chartDates]);
 
+  useEffect(() => {
+    if (!allDreams) return;
     processDreamData();
     createPlotChartDatasets();
-  }, [chartDates]);
+  }, [allDreams]);
 
   const getDateToday = (dayModifier) => {
     const date = new Date();

--- a/src/data/fakeDreams.js
+++ b/src/data/fakeDreams.js
@@ -2,7 +2,7 @@ const fakeDreams = {
   dreams: [
     {
       id: 4,
-      date: '2021/22/02',
+      date: '2021/02/22',
       title: 'Forest dream',
       description: 'I was walking through a forest when I met a talking bird',
       toneAnalysis: {
@@ -17,7 +17,7 @@ const fakeDreams = {
     },
     {
       id: 1,
-      date: '2021/23/02',
+      date: '2021/02/23',
       title: 'Bear dream',
       description: 'A bear bit me',
       toneAnalysis: {
@@ -33,7 +33,7 @@ const fakeDreams = {
     },
     {
       id: 2,
-      date: '2021/24/02',
+      date: '2021/02/24',
       title: 'Bug dream',
       description: 'A bug landed on me',
       toneAnalysis: {
@@ -48,7 +48,7 @@ const fakeDreams = {
     },
     {
       id: 3,
-      date: '2021/25/02',
+      date: '2021/02/25',
       title: 'Dog dream',
       description: 'I was walking a dog',
       toneAnalysis: {

--- a/src/data/fakeDreams.js
+++ b/src/data/fakeDreams.js
@@ -2,7 +2,7 @@ const fakeDreams = {
   dreams: [
     {
       id: 4,
-      date: '02/22/2021',
+      date: '2021/22/02',
       title: 'Forest dream',
       description: 'I was walking through a forest when I met a talking bird',
       toneAnalysis: {
@@ -17,7 +17,7 @@ const fakeDreams = {
     },
     {
       id: 1,
-      date: '02/23/2021',
+      date: '2021/23/02',
       title: 'Bear dream',
       description: 'A bear bit me',
       toneAnalysis: {
@@ -33,7 +33,7 @@ const fakeDreams = {
     },
     {
       id: 2,
-      date: '02/24/2021',
+      date: '2021/24/02',
       title: 'Bug dream',
       description: 'A bug landed on me',
       toneAnalysis: {
@@ -48,7 +48,7 @@ const fakeDreams = {
     },
     {
       id: 3,
-      date: '02/25/2021',
+      date: '2021/25/02',
       title: 'Dog dream',
       description: 'I was walking a dog',
       toneAnalysis: {

--- a/src/data/fakeDreams.js
+++ b/src/data/fakeDreams.js
@@ -8,9 +8,9 @@ const fakeDreams = {
       toneAnalysis: {
         tone_strength: {
           Analytical: 1,
-          Anger: 1,
+          Anger: 2,
           Sadness: 2,
-          Tentative: 1,
+          Tentative: 5,
         },
         unique_tones: 'Sadness, Tentative, Anger, Analytical',
       },
@@ -22,9 +22,9 @@ const fakeDreams = {
       description: 'A bear bit me',
       toneAnalysis: {
         tone_strength: {
-          Analytical: 1,
+          Analytical: 4,
           Anger: 1,
-          Joy: 2,
+          Joy: 3,
           Sadness: 2,
           Tentative: 1,
         },
@@ -39,10 +39,9 @@ const fakeDreams = {
       toneAnalysis: {
         tone_strength: {
           Analytical: 1,
-          Anger: 1,
+          Anger: 3,
           Joy: 2,
           Sadness: 2,
-          Tentative: 1,
         },
         unique_tones: 'Joy, Sadness, Tentative, Anger, Analytical',
       },
@@ -55,9 +54,8 @@ const fakeDreams = {
       toneAnalysis: {
         tone_strength: {
           Analytical: 1,
-          Anger: 1,
           Joy: 2,
-          Sadness: 2,
+          Sadness: 4,
           Tentative: 1,
         },
         unique_tones: 'Joy, Sadness, Tentative, Anger, Analytical',

--- a/src/modules/Analytics/Analytics.js
+++ b/src/modules/Analytics/Analytics.js
@@ -1,10 +1,16 @@
 import React, { useContext } from 'react';
-import UserContext from '../Context/UserContext'
+import UserContext from '../Context/UserContext';
+import TonesOverTime from '../../common/LineGraph';
 
 const Analytics = () => {
-  const user = useContext(UserContext)
+  const user = useContext(UserContext);
 
-  return <h1>Analytics</h1>;
+  return (
+    <>
+      <h1>Analytics</h1>
+      <TonesOverTime />
+    </>
+  );
 };
 
 export default Analytics;

--- a/src/modules/Analytics/Analytics.js
+++ b/src/modules/Analytics/Analytics.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import UserContext from '../Context/UserContext';
 import TonesOverTime from '../../common/LineGraph';
 
@@ -7,7 +7,7 @@ const Analytics = () => {
 
   return (
     <>
-      <h1>Analytics</h1>
+      <h5>My Dream Data</h5>
       <TonesOverTime />
     </>
   );

--- a/src/modules/Analytics/Analytics.js
+++ b/src/modules/Analytics/Analytics.js
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect } from 'react';
 import UserContext from '../Context/UserContext';
-import TonesOverTime from '../../common/LineGraph';
+import TonesOverTime from '../../common/TonesOverTime';
 
 const Analytics = () => {
   const user = useContext(UserContext);

--- a/src/modules/Dashboard/Dashboard.js
+++ b/src/modules/Dashboard/Dashboard.js
@@ -2,10 +2,7 @@ import React, { useState, useEffect, useContext } from 'react';
 import { Link } from 'react-router-dom';
 import DoughnutChart from '../../common/ToneGraph';
 import UserContext from '../Context/UserContext';
-import DreamCard from '../DreamCard/DreamCard';
-import * as API from '../../API/APIcalls';
-
-import fakeTone from '../../data/fakeTone';
+import DreamJournal from '../DreamJournal/DreamJournal';
 
 import { theme } from '../../themes/theme';
 import { Container, Grid, AppBar, Fab } from '@material-ui/core';
@@ -14,9 +11,11 @@ import { makeStyles, ThemeProvider } from '@material-ui/core/styles';
 import AddIcon from '@material-ui/icons/Add';
 
 const Dashboard = () => {
-  const [dreams, setDreams] = useState([]);
   const [tones, setTones] = useState([]);
+  const numberOfDream = 7;
   const user = useContext(UserContext);
+  const toneLabels = Object.keys(tones);
+  const toneValues = Object.values(tones);
   const useStyles = makeStyles((theme) => ({
     appBar: {
       top: 'auto',
@@ -37,32 +36,6 @@ const Dashboard = () => {
   }));
   const classes = useStyles();
 
-  useEffect(() => {
-    API.fetchUserDreams(user.token).then(
-      (response) => {
-        setDreams(response.dreams);
-      },
-      [dreams]
-    );
-  });
-
-  const recentDreams = dreams.slice(0, 2);
-  const MostRecent = recentDreams.map((dream) => {
-    return (
-      <div key={dream.id}>
-        <DreamCard
-          date={dream.date}
-          id={dream.id}
-          title={dream.title}
-          description={dream.description}
-          toneAnalysis={dream.toneAnalysis}
-        />
-      </div>
-    );
-  });
-  const toneLabels = Object.keys(tones);
-  const toneValues = Object.values(tones);
-
   return (
     <ThemeProvider theme={theme}>
       <main>
@@ -77,8 +50,7 @@ const Dashboard = () => {
             <DoughnutChart toneLabels={toneLabels} toneValues={toneValues} />
           </Grid>
           <Grid>
-            {!recentDreams.length && <h6>You have not saved any dreams yet</h6>}
-            {mostRecent}
+            <DreamJournal amount={numberOfDream} />
           </Grid>
         </Container>
         <AppBar position="fixed" className={classes.appBar}>

--- a/src/modules/Dashboard/Dashboard.js
+++ b/src/modules/Dashboard/Dashboard.js
@@ -15,7 +15,7 @@ const Dashboard = () => {
   const user = useContext(UserContext);
   const toneLabels = Object.keys(tones);
   const toneValues = Object.values(tones);
-  
+
   const useStyles = makeStyles((theme) => ({
     appBar: {
       top: 'auto',

--- a/src/modules/Dashboard/Dashboard.js
+++ b/src/modules/Dashboard/Dashboard.js
@@ -12,10 +12,10 @@ import AddIcon from '@material-ui/icons/Add';
 
 const Dashboard = () => {
   const [tones, setTones] = useState([]);
-  const numberOfDream = 7;
   const user = useContext(UserContext);
   const toneLabels = Object.keys(tones);
   const toneValues = Object.values(tones);
+  
   const useStyles = makeStyles((theme) => ({
     appBar: {
       top: 'auto',
@@ -50,7 +50,7 @@ const Dashboard = () => {
             <DoughnutChart toneLabels={toneLabels} toneValues={toneValues} />
           </Grid>
           <Grid>
-            <DreamJournal amount={numberOfDream} />
+            <DreamJournal />
           </Grid>
         </Container>
         <AppBar position="fixed" className={classes.appBar}>

--- a/src/modules/DreamCard/DreamCard.js
+++ b/src/modules/DreamCard/DreamCard.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect } from 'react';
 import {
   Grid,
   Card,
@@ -7,10 +7,12 @@ import {
   CardContent,
   IconButton,
   Collapse,
-} from '@material-ui/core'
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
-import { orange } from '@material-ui/core/colors'
-import { makeStyles } from '@material-ui/core/styles'
+  Typography
+} from '@material-ui/core';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import { orange } from '@material-ui/core/colors';
+import { makeStyles, ThemeProvider } from '@material-ui/core/styles';
+import { theme } from '../../themes/theme';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -36,9 +38,9 @@ const useStyles = makeStyles((theme) => ({
   card: {
     display: 'flex-box',
     flexDirection: 'row',
-    justifyContent: 'space-around',
+    justifyContent: 'space-between',
     color: 'orange',
-    width: '20em',
+    width: '17em',
     background: '#282c34',
     borderColor: 'orange',
   },
@@ -59,34 +61,32 @@ const useStyles = makeStyles((theme) => ({
       main: orange[400],
     },
   },
-}))
+}));
 
 const DreamCard = ({ id, date, title, description, toneAnalysis }) => {
-  const classes = useStyles()
-  const [dreams, setDreams] = useState([])
-  const [expandedId, setExpandedId] = useState(-1)
+  const classes = useStyles();
+  const [dreams, setDreams] = useState([]);
+  const [expandedId, setExpandedId] = useState(-1);
 
   const handleExpandClick = (i) => {
-    setExpandedId(expandedId === i ? -1 : i)
-  }
+    setExpandedId(expandedId === i ? -1 : i);
+  };
 
   return (
-    <div>
-      <Grid className={classes.palette.primary}>
-        <Card
-          style={{ border: 'none', boxShadow: 'none' }}
-          className={classes.outterCard}
-          key={id}
-        >
-          {date}
+    <ThemeProvider theme={theme}>
+      <div>
+        <Grid className={classes.palette.primary}>
           <Card
             key={id}
             id={id}
             style={{ margin: '1em' }}
             className={classes.card}
           >
-            <CardHeader title={title} />
-            <CardActions>
+            <CardHeader title={title} style={{ padding: '0' }} />
+            <Typography color="orange">
+              {date}
+            </Typography>
+            <CardActions disableSpacing>
               <IconButton
                 className={classes.root}
                 onClick={() => handleExpandClick(id)}
@@ -99,13 +99,13 @@ const DreamCard = ({ id, date, title, description, toneAnalysis }) => {
             <Collapse in={expandedId === id} timeout="auto" unmountOnExit>
               <CardContent>
                 <p>{description}</p>
-                <p>Dream tones: {toneAnalysis.unique_tones}</p>
+                {/* <p>Dream tones: {toneAnalysis.unique_tones}</p> */}
               </CardContent>
             </Collapse>
           </Card>
-        </Card>
-      </Grid>
-    </div>
-  )
-}
-export default DreamCard
+        </Grid>
+      </div>
+    </ThemeProvider>
+  );
+};
+export default DreamCard;

--- a/src/modules/DreamJournal/DreamJournal.js
+++ b/src/modules/DreamJournal/DreamJournal.js
@@ -42,7 +42,7 @@ const DreamJournal = () => {
   const [dreams, setDreams] = useState([]);
   const [error, setError] = useState('');
   const [expandedId, setExpandedId] = useState(-1);
-  const [dreamAmount, setDreamAmount ] = useState(7)
+  const [dreamAmount, setDreamAmount] = useState(7);
   const classes = useStyles();
   const user = useContext(UserContext);
 
@@ -51,9 +51,9 @@ const DreamJournal = () => {
   };
 
   useEffect(() => {
-    console.log(window.location.pathname)
     API.fetchUserDreams(user.token).then((response) => {
-      const mostRecentDreams = response.slice(0, (dreamAmount + 1))
+      console.log(response);
+      const mostRecentDreams = response.slice(0, dreamAmount + 1);
       setDreams(mostRecentDreams);
     });
   }, []);
@@ -69,13 +69,15 @@ const DreamJournal = () => {
           toneAnalysis={dream.toneAnalysis}
         />
       </div>
-    )
+    );
   });
 
   return (
     <ThemeProvider theme={theme}>
       <div>
-         {window.location.pathname === '/dreamjournal' && <h2 className={(classes.root, classes.title)}>Dream Journal</h2>}
+        {window.location.pathname === '/dreamjournal' && (
+          <h2 className={(classes.root, classes.title)}>Dream Journal</h2>
+        )}
         {!dreams.length && (
           <h2 className={classes.root}>You have not saved any dreams yet</h2>
         )}

--- a/src/modules/DreamJournal/DreamJournal.js
+++ b/src/modules/DreamJournal/DreamJournal.js
@@ -51,6 +51,7 @@ const DreamJournal = () => {
   };
 
   useEffect(() => {
+    console.log(window.location.pathname)
     API.fetchUserDreams(user.token).then((response) => {
       const mostRecentDreams = response.slice(0, (dreamAmount + 1))
       setDreams(mostRecentDreams);
@@ -74,7 +75,7 @@ const DreamJournal = () => {
   return (
     <ThemeProvider theme={theme}>
       <div>
-        <h2 className={(classes.root, classes.title)}>Dream Journal</h2>
+         {window.location.pathname === '/dreamjournal' && <h2 className={(classes.root, classes.title)}>Dream Journal</h2>}
         {!dreams.length && (
           <h2 className={classes.root}>You have not saved any dreams yet</h2>
         )}

--- a/src/modules/DreamJournal/DreamJournal.js
+++ b/src/modules/DreamJournal/DreamJournal.js
@@ -38,12 +38,12 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const DreamJournal = (props) => {
-  const { amount } = props
-  const classes = useStyles();
+const DreamJournal = () => {
   const [dreams, setDreams] = useState([]);
   const [error, setError] = useState('');
   const [expandedId, setExpandedId] = useState(-1);
+  const [dreamAmount, setDreamAmount ] = useState(7)
+  const classes = useStyles();
   const user = useContext(UserContext);
 
   const handleExpandClick = (i) => {
@@ -52,7 +52,7 @@ const DreamJournal = (props) => {
 
   useEffect(() => {
     API.fetchUserDreams(user.token).then((response) => {
-      const mostRecentDreams = response.slice(0, (amount + 1))
+      const mostRecentDreams = response.slice(0, (dreamAmount + 1))
       setDreams(mostRecentDreams);
     });
   }, []);

--- a/src/modules/DreamJournal/DreamJournal.js
+++ b/src/modules/DreamJournal/DreamJournal.js
@@ -38,7 +38,8 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const DreamJournal = () => {
+const DreamJournal = (props) => {
+  const { amount } = props
   const classes = useStyles();
   const [dreams, setDreams] = useState([]);
   const [error, setError] = useState('');
@@ -51,7 +52,8 @@ const DreamJournal = () => {
 
   useEffect(() => {
     API.fetchUserDreams(user.token).then((response) => {
-      setDreams(response.dreams);
+      const mostRecentDreams = response.slice(0, (amount + 1))
+      setDreams(mostRecentDreams);
     });
   }, []);
 

--- a/src/modules/Login/Login.js
+++ b/src/modules/Login/Login.js
@@ -52,7 +52,8 @@ const Login = (props) => {
   };
 
   const loginUser = () => {
-    API.fetchUserLogin(values.email)
+    // API.fetchUserLogin(values.email)
+    API.fetchUserLogin('adrew@example.com')
       .then((response) => {
         setUser({
           id: response.id,

--- a/src/modules/NewDream/NewDream.js
+++ b/src/modules/NewDream/NewDream.js
@@ -51,7 +51,7 @@ const NewDream = (props) => {
 
   const createDate = () => {
     let d = new Date();
-    return `${d.getFullYear()}/${d.getMonth()}/${d.getDate()}`;
+    return `${d.getFullYear()}/${d.getMonth()+ 1}/${d.getDate()}`;
   };
 
   useEffect(() => {

--- a/src/modules/NewDream/NewDream.js
+++ b/src/modules/NewDream/NewDream.js
@@ -50,8 +50,11 @@ const NewDream = (props) => {
   };
 
   const createDate = () => {
-    let d = new Date();
-    return `${d.getFullYear()}/${d.getMonth()+ 1}/${d.getDate()}`;
+    const date = new Date();
+    const dd = String(date.getDate()).padStart(2, '0');
+    const mm = String(date.getMonth() + 1).padStart(2, '0');
+    const yyyy = date.getFullYear();
+    return `${yyyy}/${mm}/${dd}`;
   };
 
   useEffect(() => {


### PR DESCRIPTION
## What is the change?
Add line graph displaying dream tones over time
Create new API call for dates ranges named `fetchUserDreamsByDates`, which takes in 3 inputs:
- token
- dateStart
- dateEnd
## What does it fix?
Fix RC file name, change to `TonesOverTime`
Dream input date generator now creates padded 0's inside date output
## Is this a fix or a feature? 
Feature
## Where should the reviewer start?
`TonesOverTime.js`
## How should this be tested?
`npm test`