### PR TITLE
Fix/desktop view formatting

### DIFF
--- a/src/Analytics/TonesOverTime.js
+++ b/src/Analytics/TonesOverTime.js
@@ -31,8 +31,8 @@ const TonesOverTime = () => {
 
   useEffect(() => {
     let mounted = true;
-    if (!chartDates) { 
-      setNoCharts(true)
+    if (!chartDates) {
+      setNoCharts(true);
       return;
     }
     API.fetchUserDreamsByDates(
@@ -51,8 +51,7 @@ const TonesOverTime = () => {
 
   useEffect(() => {
     let mounted = true;
-    if (!allDreams)
-      return;
+    if (!allDreams) return;
     if (mounted) {
       processDreamData();
       createPlotChartDatasets();
@@ -64,8 +63,8 @@ const TonesOverTime = () => {
   }, [allDreams]);
 
   const cleanAndStoreData = (responses) => {
-    if(!responses.length) {
-      return
+    if (!responses.length) {
+      return;
     }
     const cleanedData = responses.map((response) => {
       return {
@@ -113,7 +112,7 @@ const TonesOverTime = () => {
         toneData[date] = 0;
       }
       dateValues.push(toneData[date]);
-      setNoCharts(false)
+      setNoCharts(false);
       return dateValues;
     }, []);
     setChartTones(chartTones.push({ [tone]: toneDates }));
@@ -237,22 +236,21 @@ const TonesOverTime = () => {
       },
     },
   };
-   if (noCharts === true ) {
-     return(
-        <h4>
-          You do not have any dream data, add dreams to see your dream
-          tones
-        </h4> 
-     )
-   } else {
-  return (
-    <>
-     <Typography>Your dreams over the past</Typography>
-      <span>
+  if (noCharts === true) {
+    return (
+      <h4>
+        You do not have any dream data, add dreams to see your dream tones
+      </h4>
+    );
+  } else {
+    return (
+      <>
+        <Typography>Your dreams over the past</Typography>
+        <span>
           <FormControl>
             <Select
-              labelId='demo-simple-select-label'
-              id='demo-simple-select'
+              labelId="demo-simple-select-label"
+              id="demo-simple-select"
               value={chartDayCount}
               onChange={handleChange}
               style={{ color: 'white' }}
@@ -262,13 +260,13 @@ const TonesOverTime = () => {
               <MenuItem value={30}>Month</MenuItem>
             </Select>
           </FormControl>
-      </span>
-      <Line data={lineChartInfo.data} options={lineChartInfo.options} />
-      <Typography>Emotion Tags</Typography>
-      <Polar data={polarChartInfo.data} options={polarChartInfo.options} />
-    </>
-  );
-}
+        </span>
+        <Line data={lineChartInfo.data} options={lineChartInfo.options} />
+        <Typography>Emotion Tags</Typography>
+        <Polar data={polarChartInfo.data} options={polarChartInfo.options} />
+      </>
+    );
+  }
 };
 
 export default TonesOverTime;

--- a/src/App.js
+++ b/src/App.js
@@ -17,24 +17,24 @@ const App = () => {
 
   return (
     <UserContext.Provider value={user}>
-      <main className='App'>
-        <header className='App-header'>
+      <main className="App">
+        <header className="App-header">
           <Switch>
             <Route
               exact
-              path='/'
+              path="/"
               render={(props) => <Login {...props} setUser={setUser} />}
             />
             <Route
               exact
-              path='/signup'
+              path="/signup"
               render={(props) => <SignUp {...props} setUser={setUser} />}
             />
             <>
               <Header />
-              <Route exact path='/dashboard' component={Dashboard} />
-              <Route exact path='/dreamjournal' component={DreamJournal} />
-              <Route exact path='/newdream' component={NewDream} />
+              <Route exact path="/dashboard" component={Dashboard} />
+              <Route exact path="/dreamjournal" component={DreamJournal} />
+              <Route exact path="/newdream" component={NewDream} />
             </>
           </Switch>
         </header>

--- a/src/modules/Dashboard/Dashboard.js
+++ b/src/modules/Dashboard/Dashboard.js
@@ -4,7 +4,13 @@ import UserContext from '../Context/UserContext';
 import TonesOverTime from '../../Analytics/TonesOverTime';
 
 import { theme } from '../../themes/theme';
-import { AppBar, Fab, Toolbar, Container } from '@material-ui/core';
+import {
+  AppBar,
+  Fab,
+  Toolbar,
+  Container,
+  useMediaQuery,
+} from '@material-ui/core';
 import { makeStyles, ThemeProvider } from '@material-ui/core/styles';
 import AddIcon from '@material-ui/icons/Add';
 
@@ -25,38 +31,60 @@ const useStyles = makeStyles((theme) => ({
     right: 0,
     margin: '0 auto',
   },
-  graph: {
-    marginBottom: '2em',
-    '& .MuiSvgIcon-root': {
-      color: 'orange',
-    },
+  desktopFabButton: {
+    background: '#ff5722',
+    position: 'fixed',
+    zIndex: 1,
+    bottom: 30,
+    right: 30,
+    // margin: '0 auto',
   },
 }));
 
 const Dashboard = () => {
   const user = useContext(UserContext);
   const classes = useStyles();
+  const isMobile = useMediaQuery(theme.breakpoints.down('xs'));
 
   return (
     <ThemeProvider theme={theme}>
       <main>
         <h3>Welcome{user.name && <span>, {user.name.split(' ')[0]}</span>}</h3>
-        <Container className={classes.graph} component="div" maxWidth="sm">
+        <Container component="div" maxWidth="sm">
           <TonesOverTime />
         </Container>
-        <AppBar position="fixed" className={classes.appBar}>
-          <Toolbar variant="dense">
-            <Link to="/newdream">
-              <Fab
-                aria-label="add"
-                data-testid="addButton"
-                className={classes.fabButton}
-              >
-                <AddIcon />
-              </Fab>
-            </Link>
-          </Toolbar>
-        </AppBar>
+        {isMobile ? (
+          <>
+            <AppBar position="fixed" className={classes.appBar}>
+              <Toolbar variant="dense">
+                <Link to="/newdream">
+                  <Fab
+                    aria-label="add"
+                    data-testid="addButton"
+                    className={classes.fabButton}
+                  >
+                    <AddIcon />
+                  </Fab>
+                </Link>
+              </Toolbar>
+            </AppBar>
+          </>
+        ) : (
+          <>
+            {' '}
+            <AppBar position="fixed" className={classes.appBar}>
+              <Link to="/newdream">
+                <Fab
+                  aria-label="add"
+                  data-testid="addButton"
+                  className={classes.desktopFabButton}
+                >
+                  <AddIcon />
+                </Fab>
+              </Link>
+            </AppBar>
+          </>
+        )}
       </main>
     </ThemeProvider>
   );

--- a/src/modules/Dashboard/Dashboard.js
+++ b/src/modules/Dashboard/Dashboard.js
@@ -4,7 +4,7 @@ import UserContext from '../Context/UserContext';
 import TonesOverTime from '../../Analytics/TonesOverTime';
 
 import { theme } from '../../themes/theme';
-import { AppBar, Fab, Toolbar } from '@material-ui/core';
+import { AppBar, Fab, Toolbar, Container } from '@material-ui/core';
 import { makeStyles, ThemeProvider } from '@material-ui/core/styles';
 import AddIcon from '@material-ui/icons/Add';
 
@@ -41,15 +41,15 @@ const Dashboard = () => {
     <ThemeProvider theme={theme}>
       <main>
         <h3>Welcome{user.name && <span>, {user.name.split(' ')[0]}</span>}</h3>
-        <div className={classes.graph}>
+        <Container className={classes.graph} component="div" maxWidth="sm">
           <TonesOverTime />
-        </div>
-        <AppBar position='fixed' className={classes.appBar}>
-          <Toolbar variant='dense'>
-            <Link to='/newdream'>
+        </Container>
+        <AppBar position="fixed" className={classes.appBar}>
+          <Toolbar variant="dense">
+            <Link to="/newdream">
               <Fab
-                aria-label='add'
-                data-testid='addButton'
+                aria-label="add"
+                data-testid="addButton"
                 className={classes.fabButton}
               >
                 <AddIcon />

--- a/src/modules/DreamJournal/DreamJournal.js
+++ b/src/modules/DreamJournal/DreamJournal.js
@@ -7,7 +7,7 @@ import { act } from 'react-dom/test-utils';
 import { makeStyles, ThemeProvider } from '@material-ui/core/styles';
 import { theme } from '../../themes/theme';
 import Skeleton from '@material-ui/lab/Skeleton';
-import CircularProgress from '@material-ui/core/CircularProgress';
+import { CircularProgress, Container } from '@material-ui/core';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -91,12 +91,12 @@ const DreamJournal = () => {
   } else {
     return (
       <ThemeProvider theme={theme}>
-        <div>
+        <Container component="div" maxWidth="sm">
           <h2 className={(classes.root, classes.title)}>Dream Journal</h2>
-          {loading && <Skeleton variant='rect' className={classes.loading} />}
           {loading && <CircularProgress />}
+          {loading && <Skeleton variant="rect" className={classes.loading} />}
           {dreamCards}
-        </div>
+        </Container>
       </ThemeProvider>
     );
   }


### PR DESCRIPTION
## What is the change?
- Add new styling on dashboard view for desktop specific viewing in `Dashboard.js`
- Prettier formatting changes on `App.js` and `TonesOverTime.js`
## What does it fix?
Graph display in dashboard is now formatted to only fill the 'sm' breakpoint of 600px at max
## Is this a fix or a feature? 
Fix
## Where should the reviewer start?
`Dashboard.js` line 53
## How should this be tested?
`npm test`
## Relevant Screenshots:
Desktop:
![Screen Shot 2021-03-15 at 11 24 57 AM](https://user-images.githubusercontent.com/68252181/111195226-a75b8380-8581-11eb-8ca0-00a85b9ed120.png)
Mobile Break points:
![Screen Shot 2021-03-15 at 11 25 12 AM](https://user-images.githubusercontent.com/68252181/111195231-a9254700-8581-11eb-8001-05c1609a15b2.png)
