### PR TITLE
Feature/dream tags

### DIFF
--- a/src/API/APIcalls.js
+++ b/src/API/APIcalls.js
@@ -56,7 +56,7 @@ export const fetchUserDreamsByDates = async (token, dateStart, dateEnd) => {
   }
 };
 
-export const postUserDream = async (token, date, title, description) => {
+export const postUserDream = async (token, date, title, description, emotion) => {
   try {
     const response = await fetch(
       'https://vivid-project-backend.herokuapp.com/dreams',
@@ -70,7 +70,7 @@ export const postUserDream = async (token, date, title, description) => {
           date,
           title,
           description,
-          emotion: null,
+          emotion,
         }),
       }
     );

--- a/src/modules/DreamCard/DreamCard.js
+++ b/src/modules/DreamCard/DreamCard.js
@@ -9,6 +9,7 @@ import {
   IconButton,
   Collapse,
   Typography,
+  Chip,
 } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { orange } from '@material-ui/core/colors';
@@ -50,7 +51,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const DreamCard = ({ id, date, title, description, toneAnalysis }) => {
+const DreamCard = ({ id, date, title, description, toneAnalysis, emotion }) => {
   const [tones, setTones] = useState([]);
   const classes = useStyles();
   const [expandedId, setExpandedId] = useState(-1);
@@ -106,6 +107,23 @@ const DreamCard = ({ id, date, title, description, toneAnalysis }) => {
                     <PieChart toneLabels={toneLabels} toneValues={toneValues} />
                   )}
                   <p style={{ textAlign: 'left' }}>{description}</p>
+                  {emotion !== 'null' && (
+                    <p
+                      style={{
+                        textAlign: 'left',
+                        fontSize: '.8em',
+                        color: 'white',
+                      }}
+                    >
+                      Emotion of Dream:
+                      <Chip
+                        size='small'
+                        color='primary'
+                        label={emotion}
+                        className={classes.chip}
+                      />
+                    </p>
+                  )}
                 </CardContent>
               </Collapse>
             </Card>

--- a/src/modules/DreamCard/DreamCard.js
+++ b/src/modules/DreamCard/DreamCard.js
@@ -108,21 +108,21 @@ const DreamCard = ({ id, date, title, description, toneAnalysis, emotion }) => {
                   )}
                   <p style={{ textAlign: 'left' }}>{description}</p>
                   {emotion !== 'null' && (
-                    <p
+                    <div
                       style={{
                         textAlign: 'left',
                         fontSize: '.8em',
                         color: 'white',
                       }}
                     >
-                      Emotion of Dream:
+                      Emotion of Dream: 
                       <Chip
                         size='small'
                         color='primary'
                         label={emotion}
                         className={classes.chip}
                       />
-                    </p>
+                    </div>
                   )}
                 </CardContent>
               </Collapse>

--- a/src/modules/DreamCard/DreamCard.test.js
+++ b/src/modules/DreamCard/DreamCard.test.js
@@ -22,6 +22,7 @@ describe('DreamCard', () => {
         description='I was in the woods and it was creepy'
         date='June Tuesday 22'
         toneAnalysis={mockToneAnalysis}
+        emotion='Awkward'
       />
     );
     expect(screen.getByText('Creepy dream')).toBeInTheDocument();
@@ -45,6 +46,7 @@ describe('DreamCard', () => {
           description='I was jumping on a cloud'
           date='2021/02/23'
           toneAnalysis={mockToneAnalysis}
+          emotion='Awkward'
         />
       );
     });
@@ -57,5 +59,7 @@ describe('DreamCard', () => {
     });
     expect(screen.getByText('I was jumping on a cloud')).toBeInTheDocument();
     expect(screen.getByTestId('pieGraph')).toBeInTheDocument();
+    expect(screen.getByText('Emotion of Dream:')).toBeInTheDocument();
+    expect(screen.getByText('Awkward')).toBeInTheDocument();
   });
 });

--- a/src/modules/DreamJournal/DreamJournal.js
+++ b/src/modules/DreamJournal/DreamJournal.js
@@ -73,6 +73,7 @@ const DreamJournal = () => {
           title={dream.title}
           description={dream.description}
           toneAnalysis={dream.toneAnalysis}
+          emotion={dream.emotion}
         />
       </div>
     );

--- a/src/modules/NewDream/NewDream.js
+++ b/src/modules/NewDream/NewDream.js
@@ -37,6 +37,7 @@ const NewDream = (props) => {
   let { history } = props;
   const [dreamTitle, setDreamTitle] = useState(null);
   const [dreamBody, setDreamBody] = useState(null);
+  const [dreamEmotion, setDreamEmotion] = useState(null);
   const [error, setError] = useState({ name: false, desc: false });
   const [disabled, setDisabled] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -60,7 +61,7 @@ const NewDream = (props) => {
     setDisabled(true);
     setLoading(true);
     setDisabled(true);
-    API.postUserDream(user.token, createDate(), dreamTitle, dreamBody).then(
+    API.postUserDream(user.token, createDate(), dreamTitle, dreamBody, dreamEmotion).then(
       () => {
         setLoading(false);
         history.push('/dreamjournal');
@@ -115,6 +116,22 @@ const NewDream = (props) => {
             onChange={(e) => setDreamBody(e.target.value)}
             className={classes.input}
             data-testid={'describeInput'}
+            style={{ color: 'orange' }}
+            InputProps={{
+              className: classes.text,
+            }}
+          ></TextField>
+          <TextField
+            id='dream-emotion'
+            variant='outlined'
+            color='primary'
+            label='Emotion of Dream'
+            fullWidth
+            multiline
+            rowsMax={1}
+            onChange={(e) => setDreamEmotion(e.target.value)}
+            className={classes.input}
+            data-testid={'emotionInput'}
             style={{ color: 'orange' }}
             InputProps={{
               className: classes.text,

--- a/src/modules/NewDream/NewDream.js
+++ b/src/modules/NewDream/NewDream.js
@@ -127,8 +127,6 @@ const NewDream = (props) => {
             color='primary'
             label='Emotion of Dream'
             fullWidth
-            multiline
-            rowsMax={1}
             onChange={(e) => setDreamEmotion(e.target.value)}
             className={classes.input}
             data-testid={'emotionInput'}

--- a/src/modules/NewDream/NewDream.js
+++ b/src/modules/NewDream/NewDream.js
@@ -93,7 +93,6 @@ const NewDream = (props) => {
             error={error.name}
             required={error.name}
             id='dream-title'
-            variant='standard'
             variant='outlined'
             label='Name Your Dream'
             fullWidth

--- a/src/modules/NewDream/NewDream.test.js
+++ b/src/modules/NewDream/NewDream.test.js
@@ -101,6 +101,7 @@ describe('NewDream', () => {
       screen.getByLabelText('Describe Your Dream'),
       'There was a ghost'
     );
+    userEvent.type(screen.getByLabelText('Emotion of Dream'), 'Scary');
 
     expect(screen.getByLabelText('Name Your Dream').value).toEqual(
       'Spooky dream'
@@ -108,5 +109,6 @@ describe('NewDream', () => {
     expect(screen.getByLabelText('Describe Your Dream').value).toEqual(
       'There was a ghost'
     );
+    expect(screen.getByLabelText('Emotion of Dream').value).toEqual('Scary');
   });
 });

--- a/src/modules/NewDream/NewDream.test.js
+++ b/src/modules/NewDream/NewDream.test.js
@@ -18,11 +18,13 @@ describe('NewDream', () => {
     );
     const nameInput = screen.getByLabelText('Name Your Dream');
     const describeInput = screen.getByLabelText('Describe Your Dream');
+    const emotionInput = screen.getByLabelText('Emotion of Dream');
     const addButton = screen.getByText('Add');
 
     expect(screen.getByText('Dream Input')).toBeInTheDocument();
     expect(nameInput).toBeInTheDocument();
     expect(describeInput).toBeInTheDocument();
+    expect(emotionInput).toBeInTheDocument();
     expect(addButton).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## What is the change?
* Emotion of dream input has been added 
* Display of emotion chip has been added to dream journal view

## Is this a fix or a feature? 
* Feature

## Where should the reviewer start?
* APICalls.js line 73 

## How should this be tested?
* From the NewDream view add a new dream ensure there is a new input for "Emotion of Dream"
* After submitting the dream check that the new added dreamCard has "Emotion of Dream" displayed when the card is expanded. 
* There should be no "Emotion of Dream" displayed in the cards prior to the new card you just added


## Any relevant tickets?
#29 
